### PR TITLE
RELENG-2330 Replace the legacy /repo prefix in the Artifactory URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
  * Header, with the fields enclosed by brackets [] replaced by your own identifying
  * information: "Portions copyright [year] [name of copyright owner]".
  *
- * Copyright 2017-2020 ForgeRock AS.
+ * Copyright 2017-2023 ForgeRock AS.
  *
 -->
 
@@ -125,7 +125,7 @@
             </snapshots>
             <id>forgerock-private-releases</id>
             <name>ForgeRock Private Release Repository</name>
-            <url>https://maven.forgerock.org/repo/private-releases</url>
+            <url>https://maven.forgerock.org/artifactory/private-releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock